### PR TITLE
kickstarting now v2 support

### DIFF
--- a/expressRoutes/dataentry.js
+++ b/expressRoutes/dataentry.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+
+const bodyParser = require('body-parser');
+
+const app = express();
+
+app.set('views', path.join(__dirname, '../views'));
+app.set('view engine', 'pug');
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+
+app.get('*', (req, res) => {
+    res.render('dataentry', { title: 'Add Data' });
+})
+
+module.exports = app

--- a/expressRoutes/hello.js
+++ b/expressRoutes/hello.js
@@ -1,0 +1,9 @@
+const express = require('express')
+
+const app = express()
+
+app.get('*', (req, res) => {
+    res.send(200, '<h1>Hello, world!</h1>')
+})
+
+module.exports = app

--- a/expressRoutes/index.js
+++ b/expressRoutes/index.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+
+const bodyParser = require('body-parser');
+
+const app = express();
+
+app.set('views', path.join(__dirname, '../views'));
+app.set('view engine', 'pug');
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+
+app.get('*', (req, res) => {
+    res.render('form', { title: 'Index' });
+})
+
+module.exports = app

--- a/expressRoutes/players.js
+++ b/expressRoutes/players.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const path = require('path');
+
+const bodyParser = require('body-parser');
+
+const mongoose = require('mongoose');
+const Players = mongoose.model('Players');
+
+const app = express();
+
+app.set('views', path.join(__dirname, '../views'));
+app.set('view engine', 'pug');
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+
+app.get('*', (req, res) => {
+    Players.find()
+      .then((players) => {
+        res.render('players', { title: 'Listing players', players });
+      })
+      .catch(() => { res.send('Sorry! Something went wrong.'); });
+})
+
+module.exports = app

--- a/expressRoutes/register.js
+++ b/expressRoutes/register.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+
+const bodyParser = require('body-parser');
+
+const app = express();
+
+app.set('views', path.join(__dirname, '../views'));
+app.set('view engine', 'pug');
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+
+app.get('*', (req, res) => {
+    res.render('form', { title: 'Registration form' });
+})
+
+module.exports = app

--- a/expressRoutes/registrations.js
+++ b/expressRoutes/registrations.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const path = require('path');
+
+const bodyParser = require('body-parser');
+
+const mongoose = require('mongoose');
+const Registration = mongoose.model('Registration');
+
+const app = express();
+
+app.set('views', path.join(__dirname, '../views'));
+app.set('view engine', 'pug');
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+
+app.get('*', (req, res) => {
+    Registration.find()
+      .then((registrations) => {
+        res.render('index', { title: 'Listing registrations', registrations });
+      })
+      .catch(() => { res.send('Sorry! Something went wrong.'); });
+})
+
+module.exports = app

--- a/expressRoutes/view.js
+++ b/expressRoutes/view.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+
+const bodyParser = require('body-parser');
+
+const app = express();
+
+app.set('views', path.join(__dirname, '../views'));
+app.set('view engine', 'pug');
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+
+app.get('*', (req, res) => {
+    res.render('standard', { title: 'Test View' });
+})
+
+module.exports = app

--- a/now.json
+++ b/now.json
@@ -4,7 +4,7 @@
       "version": 2,
       "name": "express",
       "builds": [
-        { "src": "**/*.js", "use": "@now/node" }
+        { "src": "expressRoutes/**/*.js", "use": "@now/node" }
       ],
 
       "routes": [

--- a/now.json
+++ b/now.json
@@ -5,6 +5,16 @@
       "name": "express",
       "builds": [
         { "src": "**/*.js", "use": "@now/node" }
+      ],
+
+      "routes": [
+        {"src": "/", "dest": "/expressRoutes/"},
+        {"src": "/view", "dest": "/expressRoutes/view.js"},
+        {"src": "/hello", "dest": "/expressRoutes/hello.js"},
+        {"src": "/players", "dest": "/expressRoutes/players.js"},
+        {"src": "/register", "dest": "/expressRoutes/register.js"},
+        {"src": "/registrations", "dest": "/expressRoutes/registrations.js"},
+        {"src": "/dataentry", "dest": "/expressRoutes/dataentry.js"}
       ]
     
     


### PR DESCRIPTION
All the changes are done on your `now.json`, adding new explicit routes pointing directly to separated functions for handling different routes.
I have broken your `routes/index.js` into separate functions inside `expressRoutes/`.

You can find all the changes I made mentioned at
https://zeit.co/examples/express/ and
https://zeit.co/docs/v2/deployments/official-builders/node-js-now-node/​

You can test out the new settings by running `now dev`.

You might need to look at putting your mongoose logic currently in `start.js` elsewhere.